### PR TITLE
fix: should fix an invalid value on conflicted field

### DIFF
--- a/internal/notesnook/model.go
+++ b/internal/notesnook/model.go
@@ -63,7 +63,6 @@ type Nook struct {
 	Locked       bool       `json:"locked,omitempty"`
 	Favorite     bool       `json:"favorite,omitempty"`
 	LocalOnly    bool       `json:"localOnly,omitempty"`
-	Conflicted   bool       `json:"conflicted,omitempty"`
 	Readonly     bool       `json:"readonly,omitempty"`
 	NoteID       string     `json:"noteId,omitempty"`
 	Data         string     `json:"data,omitempty"`


### PR DESCRIPTION
should fix:
```
cannot unmarshal object into Go struct field Nook.conflicted of type bool
```